### PR TITLE
feat(sumdir):Sort digest list

### DIFF
--- a/sumdir
+++ b/sumdir
@@ -182,6 +182,7 @@ for opt in "${OPT_VAR_NAMES[@]}"; do
 	SCRIPT_DESCRIPTION_LINES+=("$line");
 done
 SCRIPT_VERSIONS=(
+        "0.1.?  @??????????  Sort digest list" #nosum
 	"0.1.2  @1670970402  Improving BSD/POSIX portability (Don't use perl, Support Bash 3.2.x).  b2sum:5252a8b4#l=32;size:11500" #nosum
 	"0.1.1  @1669932673  Add '--length N' option (currently for b2sum only).  b2sum:f6a28dc2#l=32;size:12099" #nosum
 	"0.1.0  @1669925986  Add '-a CMD' to choose sum command ('a' for 'algorithm', similar to 'shasum' command). Removed _OPT from env var names." #nosum
@@ -389,7 +390,8 @@ for dir in "${inputDirectories[@]}"; do
 			#| perl -pe 's/(^|\x00)\.\//\1/g' \
 		must find "${findArgs[@]}" \
 			| sed -E 's/(^|\x00)\.\//\1/g' \
-			| xargs -0 "${sumCommand[@]}";
+			| xargs -0 "${sumCommand[@]}" \
+                        | sort -k2;
 	} > "${outputFilename}";
 	sumStatus=$?;
 	yell "Generated ${dir}/${outputFilename}";


### PR DESCRIPTION
## Summary
This pull request sorts the digest list by file name.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Motivation
Facilitate manual examination of digests.

## Tests
This change has only been manually tested with Bash v5.1.16 and GNU Coreutils v8.32 on a Pop!_OS 22.04 LTS machine.

## Background
Checksum files created by `sumdir v0.1.2` (i.e `.SUM*`) list digests in an order that isn't necessarily sorted by filename. To aid manual examination of the `.SUM*` files created, I would request that the output of the digest algorithm be sorted before written.

The output of `sha256sum` or `b2sum` can be sorted by filename via `sort -k2` which sorts on the second "key" of each line. For example, a file named `unsorted.txt` containing output of a `b2sum -l64` command run on some photograph files:

```
555bc5542f9426d0  DSC00005.JPG
0cb6b86660c4b862  DSC00007.JPG
0fe3c97eab94c566  DSC00003.JPG
2772bcc89236e5db  DSC00001.JPG
fba8906f9dc3b171  DSC00004.JPG
9b3795db91262724  DSC09908.JPG
263f04a20526bb7c  DSC00006.JPG
3067a17575dd69d3  DSC00002.JPG
```

can be sorted by filename via `cat unsorted.txt | sort -k2` to produce:

```
2772bcc89236e5db  DSC00001.JPG
3067a17575dd69d3  DSC00002.JPG
0fe3c97eab94c566  DSC00003.JPG
fba8906f9dc3b171  DSC00004.JPG
555bc5542f9426d0  DSC00005.JPG
263f04a20526bb7c  DSC00006.JPG
0cb6b86660c4b862  DSC00007.JPG
9b3795db91262724  DSC09908.JPG
```

This pull request inserts a `sort -k2` command to sort the digest list by file name.